### PR TITLE
MEC-733 : Github action that validates branch names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Now you should see a node_modules directory with the modules you just installed 
 ## List of Workflow Actions
 
 * [Validating of PR titles with regular expression](./pr-title-validation/README.md)
+* [Validating branch names with regular expression](./branch-name-validation/README.md)

--- a/branch-name-validation/README.md
+++ b/branch-name-validation/README.md
@@ -1,0 +1,32 @@
+# Branch Name Validation Action
+The GitHub workflow action for validating the name of a branch submitted for PR.
+The valid PR branch name is in `camel_case`, starts with the ticket identifier followed by a short description of the feature.
+Example: `mec_123_get_registration`.
+
+## Usage
+
+To start using this action copy the following YAML into a new file at `.github/workflows/main.yml`, 
+and point the action reference `energyhub/workflow-actions/branch-name-validation@v2.0` in the `uses` section
+
+You can't rename the branch with a pull request open without deleting the branch and removing the pull request.
+
+```yaml
+name: Branch Name Validation
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  Validator-Branch-Name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: energyhub/workflow-actions/branch-name-validation@v2.0
+        with:
+          ignored_prefixes: 'rc,hotfix'
+          min_length: 5
+          regex: '^[a-z]+_\d+_[a-z0-9_]+$'
+```
+
+Triggering the action on anything other than `pull_request` will cause a failure.

--- a/branch-name-validation/action.yml
+++ b/branch-name-validation/action.yml
@@ -1,0 +1,22 @@
+name: 'Branch Name Validation'
+description: 'The GitHub workflow action for validating PR branch names with regular expression'
+inputs:
+  ignored_prefixes:
+    description: 'Comma separated list of prefixes to ignore. eg: rc,release-candidate,hotfix'
+    required: false
+    default: ''
+  min_length:
+    description: 'Minimum length of branch name'
+    required: false
+    default: '1'
+  regex:
+    description: 'Regex to validate PR branch name. Only letters and numbers allowed.'
+    required: false
+    default: '^[a-z]+_\d+_[a-z0-9_]+$'
+
+runs:
+  using: 'node16'
+  main: '../lib/branch-name-validation-action.js'
+branding:
+  icon: 'alert-triangle'
+  color: 'gray-dark'

--- a/branch-name-validation/action.yml
+++ b/branch-name-validation/action.yml
@@ -4,7 +4,7 @@ inputs:
   ignored_prefixes:
     description: 'Comma separated list of prefixes to ignore. eg: rc,release-candidate,hotfix'
     required: false
-    default: ''
+    default: 'rc,hotfix'
   min_length:
     description: 'Minimum length of branch name'
     required: false

--- a/lib/branch-name-validation-action.js
+++ b/lib/branch-name-validation-action.js
@@ -1,0 +1,44 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+const validEvent = ['pull_request'];
+
+async function run() {
+    try {
+        const eventName = github.context.eventName;
+        core.info(`Event name: ${eventName}`);
+        if (validEvent.indexOf(eventName) < 0) {
+            core.setFailed(`Invalid event: ${eventName}`);
+            return;
+        }
+
+        let branchName = github.context.payload.pull_request.head.ref;
+        core.info(`Branch name: ${branchName}`);
+
+        // Check if branch is to be ignored
+        const ignoredPrefixes = core.getInput('ignored_prefixes');
+        if (ignoredPrefixes.length > 0 && ignoredPrefixes.split(',').some((el) => branchName.startsWith(el.trim()))) {
+            core.info(`Skipping checks since ${branchName} is in the ignored list - ${ignoredPrefixes}`);
+            return
+        }
+
+        // Check min length
+        const minLen = parseInt(core.getInput('min_length'));
+        if (branchName.length < minLen) {
+            core.setFailed(`Branch ${branchName} is shorter than min length specified - ${minLen}`);
+            return;
+        }
+
+        // Check if branch passes regex
+        const regex = RegExp(core.getInput('regex'));
+        core.info(`Regex: ${regex}`);
+        if (!regex.test(branchName)) {
+            core.setFailed(`Branch ${branchName} failed to pass match regex - ${regex}`);
+        }
+
+    } catch (error) {
+        core.setFailed(error.message);
+    }
+}
+
+run();

--- a/pr-title-validation/README.md
+++ b/pr-title-validation/README.md
@@ -4,7 +4,7 @@ The GitHub workflow action for validating of PR titles with regular expression
 ## Usage
 
 To start using this action copy the following YAML into a new file at `.github/workflows/main.yml`, 
-and point the action reference `energyhub/workflow-actions/pr-title-validation@v1.0` in the `uses` section
+and point the action reference `energyhub/workflow-actions/pr-title-validation@v2.0` in the `uses` section
 
 ```yaml
 name: PR Title Validation
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: energyhub/workflow-actions/pr-title-validation@v1.0
+      - uses: energyhub/workflow-actions/pr-title-validation@v2.0
         with:
           regex: '^[A-Z]+-\d+\s:\s.*?$'
 ```


### PR DESCRIPTION
Why this PR is needed
----
The feature branch names follow the same rules:
- sneak_case
- no special characters

Examples:
- `mec_123_evse_validation`
- `liquibase`

A github action can check if a branch name for the given repository is valid. The action should be configurable:
- `regex`  : the regex the branch should match
- `ignored_prefixes`  : branch names starting with these prefixes are ignored and will not be validated
- `min_length` : min length of the branch name

Jira ticket reference : [MEC-733](https://energyhub.atlassian.net/browse/MEC-733)

What this PR includes
----
A new action that validates branch names.

How to test / verify these changes
----
Add the action to the workflow in a repo:
- good branch name: https://github.com/energyhub/mercury-edge-connect/pull/517
- bad branch names
  - https://github.com/energyhub/mercury-edge-connect/pull/518
  - https://github.com/energyhub/mercury-edge-connect/pull/519
  - https://github.com/energyhub/mercury-edge-connect/pull/520