### PR TITLE
MEC-738 : Add increment version action

### DIFF
--- a/increment-version/README.md
+++ b/increment-version/README.md
@@ -1,0 +1,45 @@
+# Version Number Incrementer Action
+The GitHub workflow action for incrementing a version number
+
+## Usage
+
+To start using this action copy the following YAML into a new file at
+`.github/workflows/increment_version.yml`,
+and point the action reference `energyhub/workflow-actions/increment-version@1.0.0` in the
+`uses` section.
+
+For example:
+```yaml
+name: Increment Feature Version
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  Minor-Version-Update:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: main
+      - id: main-version
+        name: find main branch version in VERSION.txt
+        uses: ./.github/actions/get_version
+        with:
+          version-location: main
+      - id: increment-minor-version
+        name: Increment Semantic Version
+        uses: energyhub/workflow-actions/increment-version@1.0.0
+        with:
+          current-version: ${{ steps.main-version.outputs.version }}
+          version-fragment: 'feature'
+      - id: update-version-file
+        name: Update VERSION.txt
+        run: echo "VERSION = ${{ steps.increment-minor-version.outputs.next-version }}" > ./VERSION.txt
+      - id: commit-and-push
+        name: Commit new version and push
+        run: git add ./VERSION.txt && git commit -m "Bump protos version" && git push
+
+```

--- a/increment-version/action.yml
+++ b/increment-version/action.yml
@@ -1,0 +1,25 @@
+name: "Increment Version"
+description: Given a version and release type, increment version
+inputs:
+  current-version:
+    description: 'The current semantic version you want to increment'
+    default: '0.0.0'
+    required: true
+  version-fragment:
+    description: 'The versions fragment you want to increment. possible options are [ major | feature | bug | alpha | beta | rc ]'
+    default: 'feature'
+    required: true
+outputs:
+  next-version:
+    description: 'The incremented version'
+    value: ${{ steps.increment-feature-version.next-version }}
+runs:
+  using: composite
+  steps:
+    - id: increment-feature-version
+      shell: bash
+      run: |
+        source increment_version.sh
+        increment_version ${{ inputs.current-version }} ${{ inputs.version-fragment }} || exit 1
+        
+      

--- a/increment-version/increment_version.sh
+++ b/increment-version/increment_version.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -e # fail fast
+
+# shared function that increments a part of a version string
+# https://github.com/christian-draeger/increment-semantic-version/blob/master/entrypoint.sh
+increment_version() {
+
+  prev_version="$1"; release_type="$2"
+
+  if [[ "$prev_version" == "" ]]; then
+    echo "could not read previous version"; exit 1
+  fi
+
+  possible_release_types="major feature bug alpha beta rc"
+
+  if [[ ! ${possible_release_types[*]} =~ ${release_type} ]]; then
+    echo "valid argument: [ ${possible_release_types[*]} ]"; exit 1
+  fi
+
+  major=0; minor=0; patch=0; pre=""; preversion=0
+
+  # break down the version number into it's components
+  regex="^([0-9]+).([0-9]+).([0-9]+)((-[a-z]+)([0-9]+))?$"
+  if [[ $prev_version =~ $regex ]]; then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[3]}"
+    pre="${BASH_REMATCH[5]}"
+    preversion="${BASH_REMATCH[6]}"
+  else
+    echo "previous version '$prev_version' is not a semantic version"
+    exit 1
+  fi
+
+  # increment version number based on given release type
+  case "$release_type" in
+  "major")
+    ((++major)); minor=0; patch=0; pre="";;
+  "feature")
+    ((++minor)); patch=0; pre="";;
+  "bug")
+    ((++patch)); pre="";;
+  "alpha")
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-alpha" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
+    fi
+    pre="-alpha$preversion";;
+  "beta")
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-beta" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
+    fi
+    pre="-beta$preversion";;
+  "rc")
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-rc" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
+    fi
+    pre="-rc$preversion";;
+  esac
+
+  next_version="${major}.${minor}.${patch}${pre}"
+  echo "create $release_type-release version: $prev_version -> $next_version"
+
+  echo ::set-output name=next-version::"$next_version"
+}


### PR DESCRIPTION
Why this PR is needed
----
We need an automatic way to bump protos versions for dependabot PRs.  I am creating this github action for use for that in the protos package.

Jira ticket reference : [MEC-738](https://energyhub.atlassian.net/browse/MEC-738)

What this PR includes
----
I used this github action as inspiration (almost used the shell script verbatim, is that ok? MIT license):
https://github.com/christian-draeger/increment-semantic-version