### PR TITLE
MEC-738 : Fix bash path for increment version action, it's currently erroring because it cannot find increment_version.sh

### DIFF
--- a/increment-version/action.yml
+++ b/increment-version/action.yml
@@ -16,6 +16,8 @@ outputs:
 runs:
   using: composite
   steps:
+    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
+      shell: bash
     - id: increment-feature-version
       shell: bash
       run: |


### PR DESCRIPTION
Why this PR is needed
----
As seen in https://github.com/energyhub/protocol-buffers/runs/6623922470?check_suite_focus=true this action is currently failing because it is unable to find the bash file in its path.   This should fix that problem.

Jira ticket reference : [MEC-738](https://energyhub.atlassian.net/browse/MEC-738)

What this PR includes
----
Add an action step to update the github path to that of the increment_version action so that it can find and use increment_version.sh

How to test / verify these changes
----
Will have to observe how this works in github actions as these cannot be tested locally.