### PR TITLE
MEC-738 : Fix bug with output of auto increment action

### DIFF
--- a/increment-version/action.yml
+++ b/increment-version/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   next-version:
     description: 'The incremented version'
-    value: ${{ steps.increment-feature-version.next-version }}
+    value: ${{ steps.increment-feature-version.outputs.next-version }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Why this PR is needed
----
There is a bug in the auto increment action - it is calculating the new version but that version isn't actually being outputted due to this bug.  

Jira ticket reference : [MEC-738](https://energyhub.atlassian.net/browse/MEC-738)

What this PR includes
----
Fixed incorrect variable name for output of version