### PR TITLE
EH-36879: allows anything for the title after the ticket number

### DIFF
--- a/pr-title-validation/README.md
+++ b/pr-title-validation/README.md
@@ -21,7 +21,7 @@ jobs:
       - uses: energyhub/workflow-actions/pr-title-validation@v2.3
         with:
           ignored_branch_prefixes: 'dependabot'
-          regex: '^[A-Z]+-\d+\s:\s.*?$'
+          regex: '^[A-Z]+-\d+.*?$'
 ```
 
 ### Note:

--- a/pr-title-validation/action.yml
+++ b/pr-title-validation/action.yml
@@ -4,7 +4,7 @@ inputs:
   regex:
     description: 'Regex to validate the pull request title'
     required: false
-    default: '^[A-Z]+-\d+\s:\s.*?$'
+    default: '^[A-Z]+-\d+.*?$'
   ignored_branch_prefixes:
     description: 'Comma separated list of prefixes in a branch name to ignore. eg: dependabot'
     required: false


### PR DESCRIPTION
Why this PR is needed
----
The existing regex disallows "PROJECT-XXX: Title" but allows "PROJECT-XXX : Title."

Jira ticket reference : [PROJECT-XXX](https://energyhub.atlassian.net/browse/PROJECT-XXX)

What this PR includes
----
The ADC requirement is that the PR title starts with a ticket number, but it seems like the rest of the title can be flexible, so the regex pattern is simplified here.